### PR TITLE
Add Coiled account to notebook startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ called `cng-workshop` if it does not already exist in your coiled context).
 Understanding this, all we need to do to run our jupyter server is the following:
 
 ```cmdline
-❯ coiled notebook start --software cng-workshop
+❯ coiled notebook start --software cng-workshop --account element84-demo-workspace
 ```
 
 Running this command will trigger coiled to spin up a new instance to run the


### PR DESCRIPTION
When a new user arrives, there default account will be their personal Coiled account. This PR makes sure the notebook is started within the `element84-demo-workspace` account. 


cc @jkeifer @matthewhanson 
